### PR TITLE
Remove daily update schedules from dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,12 +5,3 @@
 
 version: 2
 updates:
-  - package-ecosystem: gomod
-    directory: "/"
-    schedule:
-      interval: daily
-
-  - package-ecosystem: github-actions
-    directory: "/.github"
-    schedule:
-      interval: daily


### PR DESCRIPTION
Removed daily update schedules for gomod and GitHub Actions.